### PR TITLE
chore: Add iOS usage descriptions

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -2,10 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>To pick pictures</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>To save pictures</string>
+	<key>NSCameraUsageDescription</key>
+	<string>To take pictures</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-        <string>Photo Gallery Cap Ng</string>
+	<string>Photo Gallery Cap Ng</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
iOS app crash because of missing usage descriptions
they are mentioned in the tutorial, but not included in the app